### PR TITLE
Update Docker Sparkle Feed URL to Stable release

### DIFF
--- a/Docker/Docker.download.recipe
+++ b/Docker/Docker.download.recipe
@@ -13,7 +13,7 @@
         <key>NAME</key>
         <string>Docker</string>
         <key>SPARKLE_FEED_URL</key>
-        <string>https://download.docker.com/mac/beta/appcast.xml</string>
+        <string>https://download.docker.com/mac/stable/appcast.xml</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.6.1</string>


### PR DESCRIPTION
The Docker Sparkle Feed URL for stable is more up-to-date than the beta feed. Switch to Stable.